### PR TITLE
Fix unauthenticated ssh call to git

### DIFF
--- a/install-promtool.sh
+++ b/install-promtool.sh
@@ -4,7 +4,7 @@ function installPromtool {
   promtoolVersion="latest"
   if [[ "${promtoolVersion}" == "latest" ]]; then
     echo "Checking the latest version of Promtool"
-    promtoolVersion=$(git ls-remote --tags --refs --sort="v:refname"  git://github.com/prometheus/prometheus | grep -v '[-].*' | tail -n1 | sed 's/.*\///' | cut -c 2-)
+    promtoolVersion=$(git ls-remote --tags --refs --sort="v:refname"  https://github.com/prometheus/prometheus | grep -v '[-].*' | tail -n1 | sed 's/.*\///' | cut -c 2-)
     if [[ -z "${promtoolVersion}" ]]; then
       echo "Failed to fetch the latest version"
       exit 1


### PR DESCRIPTION
The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.