### PR TITLE
Fix the dowloadable promtool artifact script

### DIFF
--- a/install-promtool.sh
+++ b/install-promtool.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+function downloadPromtool {
+  promtoolVersion=$1
+  promUrl="https://github.com/prometheus/prometheus/releases/download/v${promtoolVersion}/prometheus-${promtoolVersion}.linux-amd64.tar.gz"
+  status_code=$(curl -s -S -L -w "%{http_code}"  -o /tmp/promtool_${promtoolVersion} ${promUrl})
+  echo $status_code
+}
+
+
 function installPromtool {
   promtoolVersion=$1
   if [[ "${promtoolVersion}" == "latest" ]]; then
@@ -11,24 +19,43 @@ function installPromtool {
     fi
   fi
 
-
-  url="https://github.com/prometheus/prometheus/releases/download/v${promtoolVersion}/prometheus-${promtoolVersion}.linux-amd64.tar.gz"
-
+  #url="https://github.com/prometheus/prometheus/releases/download/v${promtoolVersion}/prometheus-${promtoolVersion}.linux-amd64.tar.gz"
   echo "Downloading Promtool v${promtoolVersion}"
-  curl -s -S -L -o /tmp/promtool_${promtoolVersion} ${url}
+  http_code=$(downloadPromtool $promtoolVersion)
   if [ "${?}" -ne 0 ]; then
     echo "Failed to download Promtool v${promtoolVersion}"
     exit 1
   fi
-  echo "Successfully downloaded Promtool v${promtoolVersion}"
+  
+  # we should fail 5xx also 
+  if [[ $http_code -ge 500 && $status_code -lt 600 ]]; then
+    echo "HTTP Status is 5xx. Exiting..."
+    exit 1
+  fi
 
+  #retry next minor on 404
+  counter=2
+  while [ $http_code -eq 404 ]
+  do
+     echo "Release artifact for $promtoolVersion not found, trying previous available version"
+     promtoolVersion=$(git ls-remote --tags --refs --sort="v:refname"  https://github.com/prometheus/prometheus | grep -v '[-].*' | tail -n${counter} | head -1 | sed 's/.*\///' | cut -c 2-)
+     http_code=$(downloadPromtool $promtoolVersion)
+     counter=$(( counter + 1 ))
+  done
+
+  echo "Successfully downloaded Promtool v${promtoolVersion}"
+  
   echo "Unzipping Promtool v${promtoolVersion}"
+  
   tar -zxf /tmp/promtool_${promtoolVersion} --strip-components=1 --directory /usr/local/bin &> /dev/null
+  
   if [ "${?}" -ne 0 ]; then
     echo "Failed to unzip Promtool v${promtoolVersion}"
     exit 1
   fi
+  
   echo "Successfully unzipped Promtool v${promtoolVersion}"
+
 }
 
 promtoolv=${PROMTOOL_VERSION:="latest"}

--- a/install-promtool.sh
+++ b/install-promtool.sh
@@ -19,7 +19,6 @@ function installPromtool {
     fi
   fi
 
-  #url="https://github.com/prometheus/prometheus/releases/download/v${promtoolVersion}/prometheus-${promtoolVersion}.linux-amd64.tar.gz"
   echo "Downloading Promtool v${promtoolVersion}"
   http_code=$(downloadPromtool $promtoolVersion)
   if [ "${?}" -ne 0 ]; then


### PR DESCRIPTION
The script right now, support the latest tags assets there is a possibility that the prometheus repo has tagged a branch but not created any artifacts.

we should retry any previous version if we get
http return code 404 and exit on 5xx.

<details>
  <summary><strong>Sample run result</strong></summary>
  <div markdown=1>

```
./install-promtool.sh 2.52.1                                                                                                                 
Checking the latest version of Promtool                                                                                                                                                                                                      
Downloading Promtool v2.52.1                     
Release artifact for 2.52.1 not found, trying previous available version                                                                                                                                                                    
Successfully downloaded Promtool v2.52.0
Unzipping Promtool v2.52.0         
Successfully unzipped Promtool v2.52.0   
```

  </div>
</details>


